### PR TITLE
Papp 736 add query ordering support to specification pattern

### DIFF
--- a/Papp.Persistence/Source/DataAccess/ParkingAreaTransaction/IParkingAreaTransactionDataAccess.cs
+++ b/Papp.Persistence/Source/DataAccess/ParkingAreaTransaction/IParkingAreaTransactionDataAccess.cs
@@ -13,4 +13,10 @@ public interface IParkingAreaTransactionDataAccess : IGenericDataAccess<ParkingA
     /// <param name="id">An id to check for.</param>
     /// <returns>Whether or not a matching id ParkingAreaTransaction could be found.</returns>
     Task<bool> Exists(Guid id);
+
+    /// <summary>
+    /// Retrieves last Parking Area Transaction of a specific Parking Area id.
+    /// </summary>
+    /// <returns>Latest Parking Area Transaction.</returns>
+    ParkingAreaTransaction? GetLastestByParkingAreaId(int id);
 }

--- a/Papp.Persistence/Source/DataAccess/ParkingAreaTransaction/ParkingAreaTransactionDataAccess.cs
+++ b/Papp.Persistence/Source/DataAccess/ParkingAreaTransaction/ParkingAreaTransactionDataAccess.cs
@@ -25,6 +25,7 @@ public class ParkingAreaTransactionDataAccess : GenericDataAccess<ParkingAreaTra
         return this.context.ParkingAreaTransactions
             .Where(e => e.ParkingAreaId.Equals(id))
             .OrderByDescending(e => e.Timestamp)
+            .Take(1)
             .FirstOrDefault();
     }
 }

--- a/Papp.Persistence/Source/DataAccess/ParkingAreaTransaction/ParkingAreaTransactionDataAccess.cs
+++ b/Papp.Persistence/Source/DataAccess/ParkingAreaTransaction/ParkingAreaTransactionDataAccess.cs
@@ -18,4 +18,13 @@ public class ParkingAreaTransactionDataAccess : GenericDataAccess<ParkingAreaTra
         var entity = await base.GetFirstOrDefaultAsync(new Specification<ParkingAreaTransaction>(e => e.Id.Equals(id)));
         return entity != null;
     }
+
+    /// <inheritdoc/>
+    public ParkingAreaTransaction? GetLastestByParkingAreaId(int id)
+    {
+        return this.context.ParkingAreaTransactions
+            .Where(e => e.ParkingAreaId.Equals(id))
+            .OrderByDescending(e => e.Timestamp)
+            .FirstOrDefault();
+    }
 }

--- a/Papp.Persistence/Source/DataAccess/SensorUpdate/ISensorUpdateDataAccess.cs
+++ b/Papp.Persistence/Source/DataAccess/SensorUpdate/ISensorUpdateDataAccess.cs
@@ -7,4 +7,9 @@ namespace Papp.Persistence.DataAccess;
 /// </summary>
 public interface ISensorUpdateDataAccess : IGenericDataAccess<SensorUpdate>
 {
+    /// <summary>
+    /// Retrieves last Sensor Update of a specific sensor id.
+    /// </summary>
+    /// <returns>Latest Sensor Update or null if sensor had no registered updates.</returns>
+    SensorUpdate GetLastestBySensorId(string id);
 }

--- a/Papp.Persistence/Source/DataAccess/SensorUpdate/ISensorUpdateDataAccess.cs
+++ b/Papp.Persistence/Source/DataAccess/SensorUpdate/ISensorUpdateDataAccess.cs
@@ -10,6 +10,6 @@ public interface ISensorUpdateDataAccess : IGenericDataAccess<SensorUpdate>
     /// <summary>
     /// Retrieves last Sensor Update of a specific sensor id.
     /// </summary>
-    /// <returns>Latest Sensor Update or null if sensor had no registered updates.</returns>
+    /// <returns>Latest Sensor Update.</returns>
     SensorUpdate GetLastestBySensorId(string id);
 }

--- a/Papp.Persistence/Source/DataAccess/SensorUpdate/SensorUpdateDataAccess.cs
+++ b/Papp.Persistence/Source/DataAccess/SensorUpdate/SensorUpdateDataAccess.cs
@@ -12,6 +12,7 @@ public class SensorUpdateDataAccess : GenericDataAccess<SensorUpdate>, ISensorUp
         this.context = context;
     }
 
+    /// <inheritdoc/>
     public SensorUpdate? GetLastestBySensorId(string id)
     {
         return this.context.SensorUpdates

--- a/Papp.Persistence/Source/DataAccess/SensorUpdate/SensorUpdateDataAccess.cs
+++ b/Papp.Persistence/Source/DataAccess/SensorUpdate/SensorUpdateDataAccess.cs
@@ -11,4 +11,12 @@ public class SensorUpdateDataAccess : GenericDataAccess<SensorUpdate>, ISensorUp
     {
         this.context = context;
     }
+
+    public SensorUpdate? GetLastestBySensorId(string id)
+    {
+        return this.context.SensorUpdates
+            .Where(e => e.SensorId.Equals(id))
+            .OrderByDescending(e => e.Ts)
+            .FirstOrDefault();
+    }
 }

--- a/Papp.Persistence/Source/DataAccess/SensorUpdate/SensorUpdateDataAccess.cs
+++ b/Papp.Persistence/Source/DataAccess/SensorUpdate/SensorUpdateDataAccess.cs
@@ -18,6 +18,7 @@ public class SensorUpdateDataAccess : GenericDataAccess<SensorUpdate>, ISensorUp
         return this.context.SensorUpdates
             .Where(e => e.SensorId.Equals(id))
             .OrderByDescending(e => e.Ts)
+            .Take(1)
             .FirstOrDefault();
     }
 }

--- a/Papp.Persistence/Source/DataAccess/Shared/BaseSpecification.cs
+++ b/Papp.Persistence/Source/DataAccess/Shared/BaseSpecification.cs
@@ -9,12 +9,19 @@ public abstract class BaseSpecification<TEntity> : IBaseSpecification<TEntity>
     public List<string> IncludeStrings { get; }
     public bool Tracked { get; }
 
+    public Expression<Func<TEntity, object>>? OrderBy { get; private set; }
+    public Expression<Func<TEntity, object>>? OrderByDescending { get; private set; }
+    public Expression<Func<TEntity, object>>? GroupBy { get; private set; }
+
     public BaseSpecification(Expression<Func<TEntity, bool>> criteria, bool tracked = false)
     {
         this.Criteria = criteria;
         this.IncludeExpressions = new();
         this.IncludeStrings = new();
         this.Tracked = tracked;
+        this.OrderBy = null;
+        this.OrderByDescending = null;
+        this.GroupBy = null;
     }
 
     protected virtual void AddInclude(Expression<Func<TEntity, object>> expression)
@@ -25,5 +32,20 @@ public abstract class BaseSpecification<TEntity> : IBaseSpecification<TEntity>
     protected virtual void AddInclude(string includeString)
     {
         this.IncludeStrings.Add(includeString);
+    }
+
+    protected virtual void ApplyOrderBy(Expression<Func<TEntity, object>> expression)
+    {
+        OrderBy = expression;
+    }
+
+    protected virtual void ApplyOrderByDescending(Expression<Func<TEntity, object>> expression)
+    {
+        OrderByDescending = expression;
+    }
+
+    protected virtual void ApplyGroupBy(Expression<Func<TEntity, object>> expression)
+    {
+        GroupBy = expression;
     }
 }

--- a/Papp.Persistence/Source/DataAccess/Shared/IBaseSpecification.cs
+++ b/Papp.Persistence/Source/DataAccess/Shared/IBaseSpecification.cs
@@ -8,4 +8,8 @@ public interface IBaseSpecification<TEntity>
     List<Expression<Func<TEntity, object>>> IncludeExpressions { get; }
     List<string> IncludeStrings { get; }
     bool Tracked { get; }
+
+    Expression<Func<TEntity, object>>? OrderBy { get; }
+    Expression<Func<TEntity, object>>? OrderByDescending { get; }
+    Expression<Func<TEntity, object>>? GroupBy { get; }
 }

--- a/Papp.Persistence/Source/DataAccess/Shared/SpecificationEvaluator.cs
+++ b/Papp.Persistence/Source/DataAccess/Shared/SpecificationEvaluator.cs
@@ -18,7 +18,22 @@ public class SpecificationEvaluator<TEntity> where TEntity : class
         query = specification.IncludeExpressions.Aggregate(query, (current, include) => current.Include(include));
 
         query = specification.IncludeStrings.Aggregate(query, (current, include) => current.Include(include));
-        
+
+        // Apply ordering if expressions are set.
+        if (specification.OrderBy != null)
+        {
+            query = query.OrderBy(specification.OrderBy);
+        }
+        else if (specification.OrderByDescending != null)
+        {
+            query = query.OrderByDescending(specification.OrderByDescending);
+        }
+
+        if (specification.GroupBy != null)
+        {
+            query = query.GroupBy(specification.GroupBy).SelectMany(x => x);
+        }
+
         // To debug/print the sql queries that get executed on the db.
         // Console.WriteLine(query.ToQueryString());
 

--- a/Papp.Persistence/Source/Specification/Bundle/FullBundleSpecification.cs
+++ b/Papp.Persistence/Source/Specification/Bundle/FullBundleSpecification.cs
@@ -8,6 +8,7 @@ public class FullBundleSpecification : BaseSpecification<Bundle>
     {
         // Includes the Bundle toghether will some of it's nested properties.
         AddInclude($"{nameof(Bundle.ZipNavigation)}.{nameof(ZipCode.Country)}");
+        AddInclude($"{nameof(Bundle.Booths)}.{nameof(Booth.SensorInstallNavigation)}");
         AddInclude($"{nameof(Bundle.Booths)}.{nameof(Booth.ChargerNavigation)}");
         AddInclude($"{nameof(Bundle.Booths)}.{nameof(Booth.ChargerNavigation)}.{nameof(Charger.ChargerTypeNavigation)}");
         AddInclude($"{nameof(Bundle.Booths)}.{nameof(Booth.ChargerNavigation)}.{nameof(Charger.ChargerTypeNavigation)}.{nameof(ChargerType.ConnectorNavigation)}");

--- a/Papp.Persistence/Source/Specification/ParkingArea/FullParkingAreaSpecification.cs
+++ b/Papp.Persistence/Source/Specification/ParkingArea/FullParkingAreaSpecification.cs
@@ -1,0 +1,17 @@
+using System.Linq.Expressions;
+using Papp.Domain;
+using Papp.Persistence.DataAccess;
+
+public class FullParkingAreaSpecification : BaseSpecification<ParkingArea>
+{
+    public FullParkingAreaSpecification(Expression<Func<ParkingArea, bool>> criteria, bool tracked = false) : base(criteria, tracked)
+    {
+        // Includes the Bundle toghether will some of it's nested properties.
+        AddInclude($"{nameof(ParkingArea.ZipCode)}.{nameof(ZipCode.Country)}");
+        AddInclude($"{nameof(ParkingArea.SensorType)}");
+    }
+
+    public FullParkingAreaSpecification(bool tracked = false) : this(e => true, tracked)
+    {
+    }
+}


### PR DESCRIPTION
# Overview:
* [PAPP-736] Added ordering functionality to the specification pattern
* [PAPP-736] Implemented a method to retrieve lastest sensor update
* [PAPP-736] Inlcude the sensor installation with the bundle

[PAPP-736]: https://papp.atlassian.net/browse/PAPP-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAPP-736]: https://papp.atlassian.net/browse/PAPP-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PAPP-736]: https://papp.atlassian.net/browse/PAPP-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ